### PR TITLE
Refactor clients and syncInterval

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -17,11 +17,7 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/boxboat/dockcmd/cmd/aws"
-	"github.com/boxboat/dockcmd/cmd/azure"
 	dockcmdCommon "github.com/boxboat/dockcmd/cmd/common"
-	"github.com/boxboat/dockcmd/cmd/gcp"
-	"github.com/boxboat/dockcmd/cmd/vault"
 	"github.com/boxboat/dockhand-secrets-operator/pkg/common"
 	controllerv2 "github.com/boxboat/dockhand-secrets-operator/pkg/controller/v2"
 	dockhandv2 "github.com/boxboat/dockhand-secrets-operator/pkg/generated/controllers/dhs.dockhand.dev"
@@ -33,13 +29,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
-	"text/template"
 )
 
 type OperatorArgs struct {
-	MasterURL      string
-	KubeconfigFile string
-	Namespace      string
+	MasterURL                             string
+	KubeconfigFile                        string
+	Namespace                             string
 	CrossNamespaceProfileAccessAuthorized bool
 }
 
@@ -53,30 +48,6 @@ func startOperatorCmdPersistentPreRunE(cmd *cobra.Command, args []string) error 
 		return err
 	}
 	common.Log.Debugln("awsCmdPersistentPreRunE")
-	aws.Region = viper.GetString("aws-region")
-	common.Log.Debugf("Using AWS Region: {%s}", aws.Region)
-	aws.AccessKeyID = viper.GetString("aws-access-key-id")
-	aws.SecretAccessKey = viper.GetString("aws-secret-access-key")
-
-	vault.Addr = viper.GetString("vault-addr")
-	vault.Token = viper.GetString("vault-token")
-	vault.RoleID = viper.GetString("vault-role-id")
-	vault.SecretID = viper.GetString("vault-secret-id")
-
-	if aws.AccessKeyID == "" && aws.SecretAccessKey == "" {
-		aws.UseChainCredentials = true
-	}
-
-	if vault.RoleID != "" && vault.SecretID != "" {
-		vault.Auth = vault.RoleAuth
-	} else {
-		vault.Auth = vault.TokenAuth
-	}
-
-	azure.TenantID = viper.GetString("azure-tenant")
-	azure.ClientID = viper.GetString("azure-client-id")
-	azure.ClientSecret = viper.GetString("azure-client-secret")
-
 	return nil
 }
 
@@ -87,15 +58,6 @@ var startOperatorCmd = &cobra.Command{
 	PersistentPreRunE: startOperatorCmdPersistentPreRunE,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		// load function maps
-		funcMap := template.FuncMap{
-			"aws":       aws.GetAwsSecret,
-			"vault":     vault.GetVaultSecret,
-			"azureJson": azure.GetAzureJSONSecret,
-			"azureText": azure.GetAzureTextSecret,
-			"gcpJson":   gcp.GetJSONSecret,
-			"gcpText":   gcp.GetTextSecret,
-		}
 		dockcmdCommon.UseAlternateDelims = true
 
 		// load the kubeconfig file
@@ -121,7 +83,6 @@ var startOperatorCmd = &cobra.Command{
 			core.Core().V1().Secret(),
 			dhv2.Dhs().V1alpha2().Secret(),
 			dhv2.Dhs().V1alpha2().Profile(),
-			funcMap,
 			operatorArgs.CrossNamespaceProfileAccessAuthorized)
 
 		// Start all the controllers
@@ -159,99 +120,6 @@ func init() {
 		"allow-cross-namespace",
 		false,
 		"Allow Secrets to specify Profiles in external namespaces. i.e. Secret Alpha in namespace alpha could reference a profile in namespace Bravo")
-
-	startOperatorCmd.PersistentFlags().StringVar(
-		&aws.Region,
-		"aws-region",
-		"",
-		"AWS Region can alternatively be set using ${AWS_DEFAULT_REGION}")
-	_ = viper.BindEnv("aws-region", "AWS_DEFAULT_REGION")
-
-	startOperatorCmd.PersistentFlags().StringVar(
-		&aws.AccessKeyID,
-		"access-key-id",
-		"",
-		"AWS Access Key ID can alternatively be set using ${AWS_ACCESS_KEY_ID}")
-	_ = viper.BindEnv("aws-access-key-id", "AWS_ACCESS_KEY_ID")
-
-	startOperatorCmd.PersistentFlags().StringVar(
-		&aws.SecretAccessKey,
-		"aws-secret-access-key",
-		"",
-		"AWS Secret Access Key can alternatively be set using ${AWS_SECRET_ACCESS_KEY}")
-	_ = viper.BindEnv("aws-secret-access-key", "AWS_SECRET_ACCESS_KEY")
-
-	startOperatorCmd.PersistentFlags().StringVar(
-		&aws.Profile,
-		"aws-profile",
-		"",
-		"AWS Profile can alternatively be set using ${AWS_PROFILE}")
-	_ = viper.BindEnv("aws-region", "AWS_PROFILE")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&azure.TenantID,
-		"azure-tenant",
-		"",
-		"",
-		"Azure tenant ID can alternatively be set using ${AZURE_TENANT_ID}")
-	_ = viper.BindEnv("tenant", "AZURE_TENANT_ID")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&azure.ClientID,
-		"azure-client-id",
-		"",
-		"",
-		"Azure Client ID can alternatively be set using ${AZURE_CLIENT_ID}")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&azure.ClientSecret,
-		"azure-client-secret",
-		"",
-		"",
-		"Azure Client Secret Key can alternatively be set using ${AZURE_CLIENT_SECRET}")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&azure.KeyVaultName,
-		"azure-key-vault",
-		"",
-		"",
-		"Azure Key Vault Name")
-
-	_ = viper.BindEnv("azure-tenant", "AZURE_TENANT_ID")
-	_ = viper.BindEnv("azure-client-id", "AZURE_CLIENT_ID")
-	_ = viper.BindEnv("azure-client-secret", "AZURE_CLIENT_SECRET")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&vault.Addr,
-		"vault-addr",
-		"",
-		"",
-		"Vault ADDR")
-	viper.BindEnv("vault-addr", "VAULT_ADDR")
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&vault.Token,
-		"vault-token",
-		"",
-		"",
-		"Vault Token can alternatively be set using ${VAULT_TOKEN}")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&vault.RoleID,
-		"vault-role-id",
-		"",
-		"",
-		"Vault Role Id if not using vault-token can alternatively be set using ${VAULT_ROLE_ID} (also requires vault-secret-id)")
-
-	startOperatorCmd.PersistentFlags().StringVarP(
-		&vault.SecretID,
-		"vault-secret-id",
-		"",
-		"",
-		"Vault Secret Id if not using vault-token can alternatively be set using ${VAULT_SECRET_ID} (also requires vault-role-id)")
-
-	_ = viper.BindEnv("vault-token", "VAULT_TOKEN")
-	_ = viper.BindEnv("vault-role-id", "VAULT_ROLE_ID")
-	_ = viper.BindEnv("vault-secret-id", "VAULT_SECRET_ID")
 
 	_ = viper.BindPFlags(startOperatorCmd.PersistentFlags())
 }

--- a/docs/content/usage/core-concepts.md
+++ b/docs/content/usage/core-concepts.md
@@ -73,9 +73,11 @@ The Dockhand `Secret` will generate a secret of type `secretSpec.type` in the sa
 
 The `profile` field allows you to specify different `Profiles`, which gives you flexibility to connect to numerous Secrets Managers from the same cluster.
 
-The `syncInterval` field instructs the operator to poll for changes to that particular Dockhand `Secret` - something greater than `5s`. The default is `0s`, which means do not poll. Things to consider: 
+The `syncInterval` field instructs the operator to poll for changes to that particular Dockhand `Secret` - something greater than `5s`. The default is `0s`, which means do not poll. 
+
+#### `syncInterval` Considerations: 
 * Cloud Providers charge for secrets retrieval requests
-* `cacheTTL` is specified in the `Profile` so setting a `syncInterval` less than the `cacheTTL` does not make sense.
+* `cacheTTL` is specified in the `Profile` so be aware of your TTL when picking a `syncInterval`.
 * See [Auto Updates](#auto-updates) section below
 
 ### AWS Secrets Manager

--- a/docs/content/usage/core-concepts.md
+++ b/docs/content/usage/core-concepts.md
@@ -73,6 +73,11 @@ The Dockhand `Secret` will generate a secret of type `secretSpec.type` in the sa
 
 The `profile` field allows you to specify different `Profiles`, which gives you flexibility to connect to numerous Secrets Managers from the same cluster.
 
+The `syncInterval` field instructs the operator to poll for changes to that particular Dockhand `Secret` - something greater than `5s`. The default is `0s`, which means do not poll. Things to consider: 
+* Cloud Providers charge for secrets retrieval requests
+* `cacheTTL` is specified in the `Profile` so setting a `syncInterval` less than the `cacheTTL` does not make sense.
+* See [Auto Updates](#auto-updates) section below
+
 ### AWS Secrets Manager
 Dockhand `Secret` supports retrieval of an AWS Secrets Manager `json` secret using `<< (aws <secret-name> <json-key>) >>`. The `<secret-name>` supports optional `?version=<version-id>` query string.
 
@@ -87,6 +92,8 @@ metadata:
 profile: 
   name: dockhand-profile
   namespace: dockhand-secrets-operator
+# default 0s - set to an interval greater than 5s to enable polling for changes
+syncInterval: 0s
 secretSpec:
   name: example-aws-secret
   type: Opaque
@@ -210,6 +217,8 @@ metadata:
 profile:
   name: dockhand-profile
   namespace: dockhand-secrets-operator
+# default 0s - set to an interval greater than 5s to enable polling for changes
+syncInterval: 0s
 secretSpec:
   name: example-aws-secret
   type: Opaque
@@ -262,8 +271,13 @@ metadata:
   labels:
     {{- include "dockhand-demo.labels" . | nindent 4 }}
   annotations:
+    # use an annotation like this to force a sync everytime a helm deployment is made
     updateTimestamp: {{ now | date "20060102150405" | quote }}
-profile: dockhand-profile
+profile: 
+  name: dockhand-profile
+  namespace: dockhand-secrets-operator
+# default 0s - set to an interval greater than 5s to enable polling for changes
+syncInterval: 0s
 secretSpec:
   name: {{ include "dockhand-demo.fullname" . }}
   type: Opaque
@@ -275,7 +289,7 @@ data:
 
 
 ## Auto Updates
-For `DaemonSets`, `Deployments` and `StatefulSets` you can insert the following label, which make the `dockhand-secrets-operator` auto roll those types when a Dockhand `Secret` updates the `Secret` it owns.
+For `DaemonSets`, `Deployments` and `StatefulSets` you can insert the following label, which make the `dockhand-secrets-operator` auto roll those types when a Dockhand `Secret` updates the `Secret` it owns. If this option is combined with a `syncInterval` greater than `5s`, then the operator will roll these types over automatically when it updates the k8s `Secret` with changes from your Secrets Backend.
 
 ```yaml
 metadata:

--- a/docs/content/usage/crd-specs.md
+++ b/docs/content/usage/crd-specs.md
@@ -197,6 +197,15 @@ FIELDS:
 
    status	<Object>
      Provides basic status for a DockhandSecret
+
+   syncInterval	<string>
+     Specifies the time interval for polling the secrets backend for changes.
+     The default value of 0 indicates that no polling will occur and is the
+     default behavior prior to 1.1.0 release, in this case the operator will
+     only query the backend when a field in the Dockhand Secret CRD has been
+     modified. Valid time units are ns, us, ms, s, m, h, but must exceed 5s
+     (when not 0). Also note that the operator will not poll the backend more
+     frequently than the cacheTTL of the profile referenced by the Secret
 ```
 
 ### Secret.secretSpec

--- a/docs/content/usage/overview.md
+++ b/docs/content/usage/overview.md
@@ -15,4 +15,6 @@ Creation of arbitrary Kubernetes Secrets for your application deployments should
 `dockhand-secrets-operator` can also provide automatic rollover of `Deployments`, `DaemonSets` and `StatefulSets` - with the addition of a single `Label`.
 
 ## How it works
-`dockhand-secrets-operator` monitors the creation and update of Dockhand `Secret`, parses the spec and creates a corresponding Kubernetes `Secrets`. Optionally, with addition of a label on a `Deployment`, `StatefulSet` or `DaemonSet` the operator will also checksum the secret and insert a managed annotation, which will trigger an update in accordance with the update policy on each of those types. 
+`dockhand-secrets-operator` monitors the creation and update of Dockhand `Secret`, parses the spec and creates a corresponding Kubernetes `Secrets`. Optionally, with addition of a label on a `Deployment`, `StatefulSet` or `DaemonSet` the operator will also checksum the secret and insert a managed annotation, which will trigger an update in accordance with the update policy on each of those types.
+
+If you wish to have a fully automatic experience, you can enable a `syncInterval` on a per Dockhand `Secret` basis that will instruct the operator to poll your Secrets backend for changes. When a change is detected, the operator will rollout a new `Deployment`, `StatefulSet` or `DaemonSet`.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/boxboat/dockhand-secrets-operator
 go 1.17
 
 require (
-	github.com/boxboat/dockcmd v1.7.2
+	github.com/boxboat/dockcmd v1.8.0
 	github.com/gobuffalo/packr/v2 v2.8.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rancher/lasso v0.0.0-20220218171253-7b0992de7155

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/boxboat/dockcmd v1.7.2 h1:wraQNNrR2L65oZLHxmY+P3bCtU+R5Ky5OIb+WTMYtgo=
-github.com/boxboat/dockcmd v1.7.2/go.mod h1:wU7FB4PQ6X6Lckx3E5LYFAWOA3BhbTlDJWOoNka0QE4=
+github.com/boxboat/dockcmd v1.8.0 h1:bXO6wIyPnxQhYNfb4gUo/ar6SaKdX4BuFYG0c1/z1wQ=
+github.com/boxboat/dockcmd v1.8.0/go.mod h1:wU7FB4PQ6X6Lckx3E5LYFAWOA3BhbTlDJWOoNka0QE4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/pkg/apis/dhs.dockhand.dev/v1alpha2/types.go
+++ b/pkg/apis/dhs.dockhand.dev/v1alpha2/types.go
@@ -93,10 +93,11 @@ type Secret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Data       map[string]string `json:"data"`
-	SecretSpec SecretSpec        `json:"secretSpec"`
-	Profile    ProfileRef        `json:"profile"`
-	Status     SecretStatus      `json:"status,omitempty"`
+	SyncInterval string            `json:"syncInterval"`
+	Data         map[string]string `json:"data"`
+	SecretSpec   SecretSpec        `json:"secretSpec"`
+	Profile      ProfileRef        `json:"profile"`
+	Status       SecretStatus      `json:"status,omitempty"`
 }
 
 type ProfileRef struct {
@@ -116,4 +117,5 @@ type SecretStatus struct {
 	State                         SecretState `json:"state"`
 	ObservedGeneration            int64       `json:"observedGeneration"`
 	ObservedSecretResourceVersion string      `json:"observedSecretResourceVersion"`
+	SyncTimestamp                 string      `json:"syncTimestamp"`
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -17,8 +17,9 @@ limitations under the License.
 package common
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/common/tls.go
+++ b/pkg/common/tls.go
@@ -22,7 +22,7 @@ func ValidDaysRemaining(pem []byte) int {
 		Log.Warnf("could not parse certificate, %v", err)
 		return -1
 	}
-	return int(cert.NotAfter.Sub(time.Now()).Hours()/24)
+	return int(cert.NotAfter.Sub(time.Now()).Hours() / 24)
 }
 
 func GenerateSelfSignedCA(commonName string) ([]byte, []byte, error) {
@@ -58,30 +58,30 @@ func GenerateSelfSignedCA(commonName string) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("failed to encode certificate: %s", err)
 	}
 	if err := pem.Encode(&keyPem, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
-		return nil,nil, fmt.Errorf("failed to encode key: %s", err)
+		return nil, nil, fmt.Errorf("failed to encode key: %s", err)
 	}
 
 	return certPem.Bytes(), keyPem.Bytes(), nil
 }
 
-func GenerateSignedCert(commonName string, dnsNames []string, caPem []byte, caKey []byte) ([]byte,[]byte, error) {
+func GenerateSignedCert(commonName string, dnsNames []string, caPem []byte, caKey []byte) ([]byte, []byte, error) {
 	key, err := rsa.GenerateKey(rand.Reader, EncryptionBits)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate key: %s", err)
 	}
 	csrDerBytes, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{}, key)
 	if err != nil {
-		return nil,nil, fmt.Errorf("failed to generate csr: %s", err.Error())
+		return nil, nil, fmt.Errorf("failed to generate csr: %s", err.Error())
 	}
 	csr, err := x509.ParseCertificateRequest(csrDerBytes)
 	if err != nil {
-		return nil,nil, fmt.Errorf("failed to parse csr: %s", err.Error())
+		return nil, nil, fmt.Errorf("failed to parse csr: %s", err.Error())
 	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 256)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return nil,nil, fmt.Errorf("failed to generate serial number: %s", err)
+		return nil, nil, fmt.Errorf("failed to generate serial number: %s", err)
 	}
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
@@ -92,27 +92,27 @@ func GenerateSignedCert(commonName string, dnsNames []string, caPem []byte, caKe
 		Subject:      pkix.Name{CommonName: commonName},
 		DNSNames:     dnsNames,
 	}
-	caTlsPair, err := tls.X509KeyPair(caPem,caKey)
+	caTlsPair, err := tls.X509KeyPair(caPem, caKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load CA key pair: %s", err)
 	}
 
 	ca, err := x509.ParseCertificate(caTlsPair.Certificate[0])
 	if err != nil {
-		return nil,nil, fmt.Errorf("failed to parse CA certificate: %s", err)
+		return nil, nil, fmt.Errorf("failed to parse CA certificate: %s", err)
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, ca, csr.PublicKey, caTlsPair.PrivateKey)
 	if err != nil {
-		return nil,nil, fmt.Errorf("failed to create certificate: %s", err)
+		return nil, nil, fmt.Errorf("failed to create certificate: %s", err)
 	}
 
 	var certPem, keyPem bytes.Buffer
 	if err := pem.Encode(&certPem, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return nil,nil, fmt.Errorf("failed to encode certificate: %s", err)
+		return nil, nil, fmt.Errorf("failed to encode certificate: %s", err)
 	}
 	if err := pem.Encode(&keyPem, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
-		return nil,nil, fmt.Errorf("failed to encode key: %s", err)
+		return nil, nil, fmt.Errorf("failed to encode key: %s", err)
 	}
 
 	return certPem.Bytes(), keyPem.Bytes(), nil

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -22,6 +22,9 @@ import (
 	"crypto/sha1"
 	"crypto/tls"
 	"fmt"
+	"sort"
+	"strings"
+
 	dockhandv2 "github.com/boxboat/dockhand-secrets-operator/pkg/apis/dhs.dockhand.dev/v1alpha2"
 	"github.com/boxboat/dockhand-secrets-operator/pkg/common"
 	"github.com/gobuffalo/packr/v2/file/resolver/encoding/hex"
@@ -32,8 +35,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"sort"
-	"strings"
 )
 
 type PatchOperation struct {

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -20,20 +20,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
 	dockhandv2 "github.com/boxboat/dockhand-secrets-operator/pkg/apis/dhs.dockhand.dev/v1alpha2"
 	"github.com/boxboat/dockhand-secrets-operator/pkg/common"
 	"github.com/boxboat/dockhand-secrets-operator/pkg/k8s"
-	"io/ioutil"
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"net/http"
-	"sort"
-	"strings"
-	"time"
 )
 
 type Server struct {


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

- Refactor client logic based on `dockcmd` client `v1.8.0` updates
- Add `syncInterval` to `secrets.dhs.dockhand.dev` CRD, this option will instruct the operator to poll the secrets manager backend to automatically update a managed secret